### PR TITLE
Add is_correct boolean field to the guess database

### DIFF
--- a/db/migrate/20151002153458_create_guesses.rb
+++ b/db/migrate/20151002153458_create_guesses.rb
@@ -3,6 +3,7 @@ class CreateGuesses < ActiveRecord::Migration
     create_table :guesses do |t|
       t.integer :card_id, null: false
       t.integer :round_id, null: false
+      t.boolean :is_correct, null: false
       t.timestamps null: false
     end
   end


### PR DESCRIPTION
@jkrth617 I'm not sure if this was implemented in a different branch, but I added the is_correct boolean field to the guess data migration. :+1: 
