### PR TITLE
Fix logic to allow stats for incomplete rounds

### DIFF
--- a/app/models/deck.rb
+++ b/app/models/deck.rb
@@ -1,3 +1,5 @@
 class Deck < ActiveRecord::Base
   has_many :cards
+  has_many :guesses, through: :cards
+  has_many :rounds, through: :guesses
 end

--- a/app/models/round.rb
+++ b/app/models/round.rb
@@ -2,6 +2,7 @@ class Round < ActiveRecord::Base
   belongs_to :user
   has_many :guesses
   has_many :cards, through: :guesses
+  has_many :decks, through: :cards
 
   def done_cards
     guesses.where(is_correct: true).map { |guess| guess.card }

--- a/app/views/user/show.erb
+++ b/app/views/user/show.erb
@@ -1,10 +1,10 @@
 <h1>Stats for user <%=@user.username%></h1>
 <p>Hi <%=@user.first_name%>, here are your stats!</p>
 <% @user.rounds.each do |round| %>
-  Deck played: <%= round.cards.first.deck.name %> on: <%= round.created_at %>
+  Deck played: <%= round.decks.first.name %> on: <%= round.created_at %>
   Number of first-time correct guesses: <%= round.first_shot %>
   Number of total guesses: <%= round.guesses.size %>
-  Deck size: <%= round.cards.first.deck.cards.size %>
+  Deck size: <%= round.decks.first.cards.size %>
   <!-- line7  breaks the law of demeter ^^^ -->
 <% end %>
 


### PR DESCRIPTION
@jkrth617 
Fixed the bug where not completing a round would cause the statistics (profile) page to crash. Round and deck are now created via a many-to-many. I think a many-to-one makes more sense, but it didn't like that for some reason. :cry: 
