### PR TITLE
Jake/user validations

### DIFF
--- a/app/controllers/user.rb
+++ b/app/controllers/user.rb
@@ -6,10 +6,13 @@ end
 post '/registering' do
   @user = User.new(params[:user])
   @user.password = params[:password]
-  if @user.save
+  if @user.save && !params[:password].empty?
     session[:user_id] = @user.id
     redirect "/users/#{@user.id}"
   else
+    if params[:password].empty?
+      @user.errors.add("password", message = "password field blank")
+    end
     @errors = @user.errors.full_messages
     erb :'user/signup'
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,7 +1,7 @@
 class User < ActiveRecord::Base
   include BCrypt
 
-  validates :user_name, :email, :password_hash, presence: true
+  validates :username, :email, :password_hash, presence: true
   validates_uniqueness_of :email
 
   has_many :rounds

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,9 @@
 class User < ActiveRecord::Base
   include BCrypt
 
+  validates :user_name, :email, :password_hash, presence: true
+  validates_uniqueness_of :email
+
   has_many :rounds
 
   def password

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,7 +13,6 @@ class User < ActiveRecord::Base
     end
   end
 
-
   def password
     @password ||= Password.new(password_hash)
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,10 +1,18 @@
 class User < ActiveRecord::Base
   include BCrypt
 
+  has_many :rounds
+
   validates :username, :email, :password_hash, presence: true
   validates_uniqueness_of :email
+  validate :valid_email_format
 
-  has_many :rounds
+  def valid_email_format
+    if (email =~ /^[a-zA-Z0-9]*@.*\.com$/).nil?
+      errors.add(:email_error, ":you need a format XXXXXX@example.com where the Xs are numbers or letters")
+    end
+  end
+
 
   def password
     @password ||= Password.new(password_hash)


### PR DESCRIPTION
added the username, email and password presence to be true. The password presence was trickier because bcrypt always makes a password hash so saying the presence of a password hash wasnt enough. I I had to make sure that when a user was making an account thei actually filled out the password field so I had to add control flow logic to check to make sure they did this and then also add it to the errors if they didnt. The problem was because the password_hash was always there even if the user left the password field blank during creation :busts_in_silhouette::guardsman::see_no_evil::hear_no_evil::speak_no_evil:

-edit: there is an anti pattern on line 9 of the user controller because I check to make sure the password field is not an empty string. It doesnt look that pretty but I couldnt think of a better conditional than that :frowning:
